### PR TITLE
Create specific `Datadog` user with ro_admin role

### DIFF
--- a/couchbase/scripts/configure-node.sh
+++ b/couchbase/scripts/configure-node.sh
@@ -139,6 +139,12 @@ curl_check -u Administrator:password -X POST http://127.0.0.1:8095/query/service
 rm /opt/couchbase/create-dataset.json
 echo
 
-echo "Configuration completed!" | tee /dev/fd/3
+echo "Creating datadog role for metrics"
+# https://docs.couchbase.com/server/current/learn/security/roles.html
+wait_for_uri_with_auth http://127.0.0.1:8095/query/service 400
+sleep 3
+curl_check -u Administrator:password -X PUT http://localhost:8091/settings/rbac/users/local/datadog -d password="woofwoof" -d roles="ro_admin"
+
+echo "Configuration completed!"
 
 config_done

--- a/datadog/conf.d/couchbase.yaml
+++ b/datadog/conf.d/couchbase.yaml
@@ -138,12 +138,12 @@ instances:
     ## @param username - string - optional
     ## The username to use if services are behind basic or digest auth.
     #
-    username: Administrator
+    username: datadog
 
     ## @param password - string - optional
     ## The password to use if services are behind basic or NTLM auth.
     #
-    password: password
+    password: woofwoof
 
     ## @param ntlm_domain - string - optional
     ## If your services use NTLM authentication, specify


### PR DESCRIPTION
* Create `datadog` user as part of startup
* https://docs.couchbase.com/server/current/learn/security/roles.html#read-only-admin
* Minimum Datadog needs is `ro_admin`
* Change Datadog config to use `datadog`user